### PR TITLE
Feature to archive links in both of them at the same time

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -1,17 +1,20 @@
-var archiver;
-var oneClickSave;
+var archiver,
+	oneClickSave;
 
-var archiveCurrentUrlTitle = "Archive Current URL";
-var archiveCurrentUrlTitleToArchive = "Archive Current URL to archive.is";
-var archiveCurrentUrlTitleToWayback = "Archive Current URL to Wayback Machine";
+var archiveCurrentUrlTitle = "Archive Current URL",
+	archiveCurrentUrlTitleToArchive = "Archive Current URL to archive.is",
+	archiveCurrentUrlTitleToWayback = "Archive Current URL to Wayback Machine",
+	archiveCurrentUrlTitleToBoth = "Archive Current URL to both of them";
 
-var archiveImageUrlTitle = "Archive Image URL";
-var archiveImageUrlTitleToArchive = "Archive Image URL to archive.is";
-var archiveImageUrlTitleToWayback = "Archive Image URL to Wayback Machine";
+var archiveImageUrlTitle = "Archive Image URL",
+	archiveImageUrlTitleToArchive = "Archive Image URL to archive.is",
+	archiveImageUrlTitleToWayback = "Archive Image URL to Wayback Machine",
+	archiveImageUrlTitleToBoth = "Archive Image URL to both of them";
 
-var archiveLinkUrlTitle = "Archive Link URL"
-var archiveLinkUrlTitleToArchive = "Archive Link URL to archive.is"
-var archiveLinkUrlTitleToWayback = "Archive Link URL to Wayback Machine"
+var archiveLinkUrlTitle = "Archive Link URL",
+	archiveLinkUrlTitleToArchive = "Archive Link URL to archive.is",
+	archiveLinkUrlTitleToWayback = "Archive Link URL to Wayback Machine",
+	archiveLinkUrlTitleToBoth = "Archive Link URL to both of them";
 
 function saveCurrentUrl() {
 	browser.tabs.query({active: true, currentWindow: true}, function(tabs) {
@@ -35,6 +38,18 @@ function archiveUrlArchive(url) {
 function archiveUrlWayback(url) {
 	browser.tabs.create({
 		url: "https://web.archive.org/save/" + url
+	})
+}
+
+function archiveUrlToBoth(url) {
+	browser.tabs.create({
+		url: "https://archive.is/?run=1&url=" + url,
+		active: false
+	})
+	
+	browser.tabs.create({
+		url: "https://web.archive.org/save/" + url,
+		active: false
 	})
 }
 
@@ -87,6 +102,12 @@ function updateArchiver() {
 		})
 
 		browser.contextMenus.create({
+			id: "archive-url-both",
+			title: archiveCurrentUrlTitleToBoth,
+			contexts: ["page"]
+		})
+
+		browser.contextMenus.create({
 			id: "archive-image-url-archive",
 			title: archiveImageUrlTitleToArchive,
 			contexts: ["image"]
@@ -99,6 +120,12 @@ function updateArchiver() {
 		})
 
 		browser.contextMenus.create({
+			id: "archive-image-url-both",
+			title: archiveImageUrlTitleToBoth,
+			contexts: ["image"]
+		})
+
+		browser.contextMenus.create({
 			id: "archive-link-url-archive",
 			title: archiveLinkUrlTitleToArchive,
 			contexts: ["link"]
@@ -107,6 +134,12 @@ function updateArchiver() {
 		browser.contextMenus.create({
 			id: "archive-link-url-wayback",
 			title: archiveLinkUrlTitleToWayback,
+			contexts: ["link"]
+		})
+
+		browser.contextMenus.create({
+			id: "archive-link-url-both",
+			title: archiveLinkUrlTitleToBoth,
 			contexts: ["link"]
 		})
 	}
@@ -175,14 +208,26 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
 		case "archive-link-url-archive":
 			archiveUrlArchive(info.linkUrl);
 			break;
+		case "archive-link-url-both":
+			archiveUrlToBoth(info.linkUrl);
+			break;
 		case "archive-url-wayback":
 			archiveUrlWayback(tab.url);
+			break;
+		case "archive-url-both":
+			archiveUrlToBoth(tab.url);
 			break;
 		case "archive-image-url-wayback":
 			archiveUrlWayback(info.srcUrl);
 			break;
+		case "archive-image-url-both":
+			archiveUrlToBoth(info.srcUrl);
+			break;
 		case "archive-link-url-wayback":
 			archiveUrlWayback(info.linkUrl);
+			break;
+		case "archive-link-url-both":
+			archiveUrlToBoth(info.linkUrl);
 			break;
 	}
 });

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -20,5 +20,6 @@
 
 		<div class="archiver" id="wayback">Save to Wayback Machine</div>
 		<div class="archiver" id="archive">Save to archive.is</div>
+		<div class="archiver" id="both">Save to both of them</div>
 	</body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -10,6 +10,19 @@ document.addEventListener("click", function(e) {
 					url: "https://archive.is/?run=1&url=" + tabs[0].url
 				})
 			}
+
+			if (e.target.id == "both") {
+				browser.tabs.create({
+					url: "https://archive.is/?run=1&url=" + tabs[0].url,
+					active: false
+				})
+				
+				browser.tabs.create({
+					url: "https://web.archive.org/save/" + tabs[0].url,
+					active: false
+				})
+			}
+			
 			else {
 				browser.tabs.create({
 					url: "https://web.archive.org/save/" + tabs[0].url


### PR DESCRIPTION
Hello,

I'm using your archive url firefox extension to save snapshots of pages. There was only one thing that I miss. I would like to see a button to save in both of them at the same time.

![image](https://user-images.githubusercontent.com/15094113/36949112-0197f392-1ff5-11e8-8f2c-2d5aae5b46b6.png)

So I created this pull request. When you fire, it creates two tabs in the background to archive. Hope that I didn't break anything. 